### PR TITLE
bugfix: cancel_order

### DIFF
--- a/zipline/gens/brokers/tdx_broker.py
+++ b/zipline/gens/brokers/tdx_broker.py
@@ -274,9 +274,11 @@ class TdxBroker(Broker):
         return rt
 
     def cancel_order(self, order_id):
+        if order_id not in self.orders:  # order become transaction, can't cancel
+            return
         tdx_order_id = self.orders[order_id].broker_order_id
-        broker_id = self._client.get_stock_type(self.orders[order_id].symbol)
-        self._client.cancel(broker_id, tdx_order_id)
+        broker_id = self._client.get_stock_type("{:6d}".format(self.orders[order_id].asset.sid))
+        self._client.cancel_orders(broker_id, tdx_order_id)
 
     def get_last_traded_dt(self, asset):
         self.subscribe_to_market_data(asset)


### PR DESCRIPTION
cancel_order can't work, reason: 1) api use cancel, should be cancel_orders 2) expect nametuple, real is zp order